### PR TITLE
Bugfix: Comandos da CLI não funcionam quando o arquivo de credentials não existe

### DIFF
--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -12,11 +12,13 @@ const { default: Command } = require('@oclif/command')
 const credentials = require('../config/credentials')
 const ExtensionService = require('../services/extension')
 const JSONManager = require('../config/JSONManager')
-const socket = require('../config/socket')
+const Socket = require('../config/socket')
 
 class ServeCommand extends Command {
   constructor () {
     super(...arguments)
+
+    this.socket = new Socket()
 
     credentials.load()
 
@@ -111,7 +113,7 @@ class ServeCommand extends Command {
       extensionsData.forEach(async extensionData => {
         console.log(`Built extension ${extensionData.extensionInfo.name}`)
 
-        const err = await socket.emit({
+        const err = await this.socket.emit({
           event: 'reload-extension',
           data: {
             ...extensionData,

--- a/src/config/socket.js
+++ b/src/config/socket.js
@@ -25,7 +25,7 @@ module.exports = new (class Socket {
     this.connInterval = setInterval(() => {
       if (this.socket !== null) {
         clearInterval(this.connInterval)
-      } else {
+      } else if (credentials?.user?.uid) {
         this.socket = new Ws(socketServerUrl, {
           Cookie: `uuid=${credentials.user.uid}`
         })

--- a/src/config/socket.js
+++ b/src/config/socket.js
@@ -4,7 +4,7 @@ const Ws = require('ws')
 const socketServerUrl =
   process.env.WEBSOCKET_URL || 'wss://develop.ws.quoti.cloud/'
 
-module.exports = new (class Socket {
+module.exports = class Socket {
   constructor () {
     /**
      * @type {WebSocket}
@@ -67,4 +67,4 @@ module.exports = new (class Socket {
       this.socket.send(JSON.stringify({ event, data }), r => resolve(r))
     )
   }
-})()
+}


### PR DESCRIPTION
Resolve o erro com a utilização da CLI quando o arquivo de credenciais não existe ainda. 

O socket se conectava com o backend para qualquer comando, pois a configuração era instanciada no mesmo momento que era exportada (Singleton), esse bugfix checa se o arquivo de credenciais existe antes de tentar se conectar e faz a configuração do socket deixar de ser um Singleton, apenas instanciando a mesma quando o comando `serve` for executado.