### PR TITLE
Remove apenas o arquivo de build da extensão que está sendo compilada

### DIFF
--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -246,6 +246,7 @@ class ServeCommand extends Command {
       : 'Observando alterações em qualquer extensão'
 
     this.logger.info(watchingChangesMessage)
+    fs.rmSync('./dist', { recursive: true, force: true })
   }
 
   async getAliasFromVueConfig () {

--- a/src/services/extension.js
+++ b/src/services/extension.js
@@ -114,7 +114,7 @@ class ExtensionService {
     try {
       this.vueCliService.init(mode)
       this.spinner.start(`Fazendo build da extensão ${this.manifest.name} ...`)
-      const dest = 'dist/'
+      const dest = `dist/${this.manifest.extensionUUID}`
       const name = `dc_${this.manifest.extensionUUID}`
       await this.vueCliService.run('build', {
         mode,


### PR DESCRIPTION
https://www.notion.so/beyondco/Erro-durante-o-comando-qt-serve-ao-salvar-uma-extens-o-rapidamente-repetidas-vezes-8da714c95f2344f986d4a50215fdfe20