### PR TITLE
Configura um novo argumento (remoteExtensionUUID) para a função build

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -95,7 +95,10 @@ class DeployCommand extends Command {
 
     let extensionPath = entryPointPath
     if (manifest.type === 'build') {
-      extensionPath = await this.extensionService.build(entryPointPath)
+      const remoteExtensionUUID = remoteExtension?.extension_uuid
+      extensionPath = await this.extensionService.build(entryPointPath, {
+        remoteExtensionUUID
+      })
     }
     await this.extensionService.upload(fs.readFileSync(extensionPath), filename)
     try {

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -72,9 +72,12 @@ class ServeCommand extends Command {
         let distPath = path
         const manifest = manifestsByPaths[path]
         const extensionService = new ExtensionService(manifest)
+        const remoteExtensionUUID =
+          remoteExtensionsByPaths?.[path]?.extension_uuid
         if (manifestsByPaths[path].type === 'build') {
           distPath = await extensionService.build(path, {
-            mode: 'staging'
+            mode: 'staging',
+            remoteExtensionUUID
           })
         }
 

--- a/src/services/extension.js
+++ b/src/services/extension.js
@@ -101,11 +101,10 @@ class ExtensionService {
     return uuid
   }
 
-  async build (entry, { mode } = { mode: 'production' }) {
+  async build (entry, { mode, remoteExtensionUUID } = { mode: 'production' }) {
     if (!this.manifest.extensionUUID) {
-      const extension = await this.getExtension(this.manifest.extensionId)
-      if (this.extension?.extensionUUID) {
-        this.manifest.extensionUUID = extension.extensionUUID
+      if (remoteExtensionUUID) {
+        this.manifest.extensionUUID = remoteExtensionUUID
         this.manifest.save()
       } else {
         await this.createExtensionUUID()


### PR DESCRIPTION
https://www.notion.so/beyondco/qt-deploy-apresenta-erro-esporadicamente-d95ffab6a65f47858e274c48a1d16219