### PR TITLE
Permite controlar propriedade 'meta' presente no dynamicComponent através do manifest

### DIFF
--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -127,6 +127,7 @@ class LinkExtensionCommand extends Command {
     manifest.type = extensionData.type === 'Com build' ? 'build' : 'noBuild'
     manifest.name = extensionData.title
     manifest.extensionUUID = extensionData.extensionUUID
+    manifest.meta = extensionData.meta
     manifest.institution = institution
 
     manifest.save()

--- a/src/services/extension.js
+++ b/src/services/extension.js
@@ -42,7 +42,8 @@ class ExtensionService {
         url,
         version,
         fileVuePrefix,
-        activated: true
+        activated: true,
+        meta: this.manifest.meta || {}
       },
       { headers: { Authorization: `Bearer ${token}` } }
     )


### PR DESCRIPTION
https://www.notion.so/beyondco/Permitir-que-o-desenvolvedor-de-extens-es-defina-no-arquivo-manfest-json-a-visibilidade-do-menu-late-6a403a4ea0cb4b538d3204a73d70e083