### PR TITLE
Mostrando mais informações no comando qt login

### DIFF
--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -1,13 +1,27 @@
 const credentials = require('../config/credentials')
 const Command = require('../base.js')
-
+const Auth = require('../services/auth')
 class LoginCommand extends Command {
   async run () {
-    // The login itself is done in the hook so just display a message
-    if (credentials.exists()) {
-      this.logger.success('Usuário com login realizado')
+    const { previouslyLogger } = await Auth.silentLogin()
+    if (previouslyLogger) {
+      this.logger.info('Você já realizou login anteriormente.\n')
+
+      this.logger.info(`Organização: ${credentials.institution}`)
+      this.logger.info(`Usuário: ${credentials.user?.displayName}`)
+      this.logger.info(`Email: ${credentials.user?.email}`)
+      if (credentials.devSessionId) {
+        this.logger.info(`sessionId: ${credentials.devSessionId}`)
+      }
+
+      this.logger.info(
+        '\n"qt login -f" : Para que seja ignorada sessão atual e seja forçado o login em uma nova conta'
+      )
+      this.logger.info(
+        '"qt logout" : Torna possível sair da conta atual e ficar desconectado'
+      )
     } else {
-      this.logger.error('Erro no login')
+      this.logger.success('Login realizado com sucesso')
     }
   }
 

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -1,9 +1,12 @@
 const credentials = require('../config/credentials')
 const Command = require('../base.js')
 const Auth = require('../services/auth')
+const { flags } = require('@oclif/command')
 class LoginCommand extends Command {
   async run () {
-    const { previouslyLogger } = await Auth.silentLogin()
+    const { previouslyLogger } = await Auth.silentLogin({
+      force: this.flags.force
+    })
     if (previouslyLogger) {
       this.logger.info('Você já realizou login anteriormente.\n')
 
@@ -23,6 +26,13 @@ class LoginCommand extends Command {
     } else {
       this.logger.success('Login realizado com sucesso')
     }
+  }
+
+  static flags = {
+    force: flags.boolean({
+      char: 'f',
+      description: 'Força o login em uma nova conta'
+    })
   }
 
   static description = 'Realiza login em uma organização do Quoti'

--- a/src/hooks/login.js
+++ b/src/hooks/login.js
@@ -2,7 +2,11 @@ const Auth = require('../services/auth')
 
 module.exports = async function (options) {
   const command = options.Command
-  if (command.id !== 'logout' && command.id !== 'autocomplete') {
+  if (
+    command.id !== 'login' &&
+    command.id !== 'logout' &&
+    command.id !== 'autocomplete'
+  ) {
     await Auth.silentLogin()
   }
 }

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -6,11 +6,21 @@ const chalk = require('chalk')
 const inquirer = require('inquirer')
 const api = require('../config/axios')
 const Logger = require('../config/logger')
+const { getFrontBaseURL } = require('../utils/index')
 
 class Auth {
+  getTokenAccessURL (orgSlug) {
+    const baseUrl = getFrontBaseURL()
+    return `${baseUrl}/${orgSlug}/dynamicComponents`
+  }
+
   async login () {
     console.log(chalk`${logo}`)
     const institution = await this.insertOrgSLug()
+    const tokenAccessURL = this.getTokenAccessURL(institution)
+    Logger.info(
+      `Clique no botão "Obter o token de acesso" em ${tokenAccessURL}`
+    )
     const customToken = await this.insertToken()
     try {
       const authFirebase = await app.auth().signInWithCustomToken(customToken)
@@ -68,6 +78,7 @@ class Auth {
     if (!credentials.exists()) {
       await this.login()
       credentials.load()
+      return { previouslyLogger: false }
     } else {
       credentials.load()
       try {
@@ -78,6 +89,7 @@ class Auth {
           userData
         )
         await firebase.auth().updateCurrentUser(user)
+        return { previouslyLogger: true }
       } catch (error) {
         this.logger.error(error)
         this.logger.error('Erro ao carregar credenciais')

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -74,8 +74,8 @@ class Auth {
     return inputToken
   }
 
-  async silentLogin () {
-    if (!credentials.exists()) {
+  async silentLogin ({ force } = {}) {
+    if (!credentials.exists() || force) {
       await this.login()
       credentials.load()
       return { previouslyLogger: false }


### PR DESCRIPTION
# Alterações realizadas nessa P.R
-- Hook de login não é chamado no comando login
-- Exibe url de obtenção do token de acesso durante o comando qt login
-- Exibe nome, email, devSessionId e orgSlug no comando qt login( apenas quando o usuário está logado e executa o comando qt login)