### PR TITLE
Melhora mensagem de erro ao fazer "link" em extensão e o usuário não possuir as permissões necessárias

### DIFF
--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -58,7 +58,11 @@ class LinkExtensionCommand extends Command {
       credentials.institution,
       this.flags.build
     ).catch(err => {
-      spinner.fail('Falha ao carregar extensões')
+      let errorMessage = 'Falha ao carregar extensões'
+      if (err.response.status === 403) {
+        errorMessage = 'Usuário com permissões insuficientes'
+      }
+      spinner.fail(errorMessage)
       throw err
     })
 


### PR DESCRIPTION
De acordo com a task:
[Task](https://www.notion.so/beyondco/Erro-quando-o-usu-rio-n-o-tem-permiss-o-para-realizar-o-qt-link-04c33944b5744560b5085affc6af8882?pvs=4)