### PR TITLE
Permite atualizar extensão em várais organizações

### DIFF
--- a/src/utils/legis-erp.js
+++ b/src/utils/legis-erp.js
@@ -1,0 +1,30 @@
+const api = require('../config/axios')
+
+/**
+ *
+ * @param {string|number} buffer
+ * @param {number} now
+ */
+async function getOrgsLegisErp (token) {
+  const { data: orgs } = await api.axios.get(
+    'legis/resources/legis_erp',
+    {
+      params: {
+        limit: 9000,
+        where: {
+          syncByLegisErpTemplate: 1
+        }
+      },
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    }
+  )
+  const orgSlugs = orgs.map(org => org.orgSlug)
+  return orgSlugs
+}
+
+module.exports = {
+  getOrgsLegisErp
+
+}


### PR DESCRIPTION
## O que essa P.R faz
1. Permite instalar extensão em várias organizações 

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances `publish.js` to update extensions across multiple organizations, adding support for 'legis-erp' and renaming flags for clarity.
> 
>   - **Behavior**:
>     - Allows publishing extensions to multiple organizations with `--orgs-to-update` and `--project` flags in `publish.js`.
>     - Supports 'legis-erp' project for organization updates using `getOrgsLegisErp()`.
>   - **Flags**:
>     - Renames `--orgs` flag to `--orgs-to-update` in `publish.js`.
>     - Adds `--project` flag to specify project-based organization updates.
>   - **Utils**:
>     - Adds `getOrgsLegisErp()` in `legis-erp.js` to fetch organizations for 'legis-erp'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=byndcloud%2Fquoti-cli&utm_source=github&utm_medium=referral)<sup> for 6d81b8a95fc6a1f0cdba6c4f58b1830da1877e73. You can [customize](https://app.ellipsis.dev/byndcloud/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->